### PR TITLE
Update dependencies to the version 2.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,8 +85,8 @@ Fingerprint PRO Android uses FingerprintJS Android as a dependency.
 
 ```gradle
 dependencies {
-  implementation "com.fingerprint.android:pro:2.2.0"
-  implementation "com.github.fingerprintjs:fingerprint-android:1.3.0"
+  implementation "com.fingerprint.android:pro:2.2.1"
+  implementation "com.github.fingerprintjs:fingerprint-android:2.0.0"
 
 
   // If you use Java for you project, add also this line

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,13 +5,13 @@ plugins {
 }
 
 android {
-    compileSdk 31
+    compileSdk 33
     buildToolsVersion "30.0.3"
 
     defaultConfig {
         applicationId "com.fingerprintjs.android.fpjs_pro_demo"
         minSdk 21
-        targetSdk 31
+        targetSdk 33
         versionCode Integer.parseInt(project.VERSION_CODE)
         versionName project.VERSION_NAME
 
@@ -43,15 +43,15 @@ android {
 }
 
 dependencies {
-    implementation "com.fingerprint.android:pro:2.2.0"
-    implementation "com.github.fingerprintjs:fingerprint-android:1.3.0"
+    implementation "com.fingerprint.android:pro:2.2.1"
+    implementation "com.github.fingerprintjs:fingerprint-android:2.0.0"
     implementation 'org.osmdroid:osmdroid-android:6.1.11'
     implementation "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0"
-    implementation 'androidx.core:core-ktx:1.8.0'
-    implementation 'androidx.appcompat:appcompat:1.4.2'
-    implementation 'com.google.android.material:material:1.6.1'
-    implementation 'androidx.security:security-crypto-ktx:1.1.0-alpha03'
+    implementation 'androidx.core:core-ktx:1.9.0'
+    implementation 'androidx.appcompat:appcompat:1.5.1'
+    implementation 'com.google.android.material:material:1.7.0'
+    implementation 'androidx.security:security-crypto-ktx:1.1.0-alpha04'
     testImplementation 'junit:junit:4.13.2'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.3'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.4'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.0'
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,5 +2,5 @@ android.enableJetifier=true
 kotlin.code.style=official
 android.useAndroidX=true
 org.gradle.jvmargs=-Xmx4096m -Dfile.encoding=UTF-8
-VERSION_NAME=2.2.0
-VERSION_CODE=9
+VERSION_NAME=2.2.1
+VERSION_CODE=10


### PR DESCRIPTION
Add compatibility with OSS 2.0.0, which required recompilation of the library due to changing public interfaces and making them classes (as was reported in [issue](https://github.com/fingerprintjs/fingerprintjs-pro-android-demo/issues/28)). No code changes required, OSS 1.3.0 works with PRO 2.2.0, OSS 2.0.0+ works with PRO 2.2.1+