### PR TITLE
Release/2.3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,31 +83,19 @@ repositories {
 
 }
 ```
-#### Add dependencies to your `build.gradle` file.
-
-Fingerprint PRO Android uses FingerprintJS Android as a dependency.
+#### Add the dependency to your `build.gradle` file.
 
 ```gradle
 dependencies {
-  implementation "com.fingerprint.android:pro:2.3.1"
-  implementation "com.github.fingerprintjs:fingerprint-android:2.0.0"
-
-
-  // If you use Java for you project, add also this line
-  implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-```
-
-When using Kotlin, also make sure you have specified Kotlin version in your `build.gradle` file:
-```gradle
-buildscript {
-    ext.kotlin_version = 'your-kotlin-version'
     ...
+  implementation "com.fingerprint.android:pro:2.3.1"
+}
 ```
-*Note: You can find your Kotlin version in Android Studio > File > Settings > Languages & Frameworks > Kotlin.*
 
-Sync gradle settings.
+Note: Fingerprint PRO Android uses [FingerprintJS Android](https://github.com/fingerprintjs/fingerprintjs-android) and [kotlin-stdlib](https://kotlinlang.org/api/latest/jvm/stdlib/) as dependencies.
 
-*Note: The library depends on [kotlin-stdlib](https://kotlinlang.org/api/latest/jvm/stdlib/). If your application is written in Java, add `kotlin-stdlib` dependency first (it's lightweight and has excellent backward and forward compatibility).*
+#### Sync gradle settings.
+
 
 #### Get the visitor identifier
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Fingerprint PRO Android uses FingerprintJS Android as a dependency.
 
 ```gradle
 dependencies {
-  implementation "com.fingerprint.android:pro:2.3.0"
+  implementation "com.fingerprint.android:pro:2.3.1"
   implementation "com.github.fingerprintjs:fingerprint-android:2.0.0"
 
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -55,9 +55,7 @@ android {
 }
 
 dependencies {
-    def fpProVersion = project.VERSION_NAME
-    implementation "com.fingerprint.android:pro:$fpProVersion"
-    implementation "com.github.fingerprintjs:fingerprint-android:2.0.0"
+    implementation "com.fingerprint.android:pro:${project.VERSION_NAME}"
 
     implementation 'org.osmdroid:osmdroid-android:6.1.11'
     implementation "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -58,12 +58,14 @@ dependencies {
     def fpProVersion = project.VERSION_NAME
     implementation "com.fingerprint.android:pro:$fpProVersion"
     implementation "com.github.fingerprintjs:fingerprint-android:2.0.0"
+
     implementation 'org.osmdroid:osmdroid-android:6.1.11'
     implementation "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0"
-    implementation 'androidx.core:core-ktx:1.9.0'
-    implementation 'androidx.appcompat:appcompat:1.5.1'
-    implementation 'com.google.android.material:material:1.7.0'
-    implementation 'androidx.security:security-crypto-ktx:1.1.0-alpha04'
+    implementation 'androidx.core:core-ktx:1.10.0'
+    implementation 'androidx.appcompat:appcompat:1.6.1'
+    implementation 'com.google.android.material:material:1.8.0'
+    implementation 'androidx.security:security-crypto-ktx:1.1.0-alpha05'
+
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.4'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.0'

--- a/build.gradle
+++ b/build.gradle
@@ -1,12 +1,12 @@
 buildscript {
-    ext.kotlin_version = '1.6.10'
+    ext.kotlin_version = '1.8.0'
     repositories {
         google()
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.2.1'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.10"
+        classpath 'com.android.tools.build:gradle:7.4.2'
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${kotlin_version}"
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,5 +2,5 @@ android.enableJetifier=true
 kotlin.code.style=official
 android.useAndroidX=true
 org.gradle.jvmargs=-Xmx4096m -Dfile.encoding=UTF-8
-VERSION_NAME=2.3.0
-VERSION_CODE=13
+VERSION_NAME=2.3.1
+VERSION_CODE=14

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Tue Jul 19 16:41:47 MSK 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
- integration steps improvements: users don't have to specify the library's runtime dependencies by hand in their build.gradle files anymore
- request compression to reduce network usage
- upgrade to Kotlin 1.8.0
- minor stability improvements
